### PR TITLE
Fixing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tags:
 - [avsm/ppa-opam-experimental](https://launchpad.net/~avsm/+archive/ubuntu/ppa-opam-experimental) is where the bleeding edge snapshots are uploaded. You should only need this if you are the maintainer of this repository.
 
 
-## Relationship to upstream
+## Relationship to upstream
 
 Note that these are *not* upstream packages of the same high quality
 as maintained in Debian.  They are simply the minimal packages to get
@@ -25,7 +25,7 @@ Eventually, opam2 will land in the upstream Debian and Ubuntu repositories
 and these PPAs will no longer be required.
 
 
-## Running It
+## Running It
 
 You shouldn't need to run these scripts, but if you do, then you will need a
 `.gnupg` directory setup to sign the Debian packages.  `scripts/build.sh` goes


### PR DESCRIPTION
ref https://twitter.com/avsm/status/1061936734408265729

You need a space character after `#` in Github Flavored Markdown for it to render as a heading.

I sometimes have this problem on my Mac where I by accident insert a non-breaking space character instead of a normal one (on macOS this can happen if you hold down the Alt-key while typing space, it's probably something similar on Windows / Linux).

If you're a Vim user you can check this out by setting the following two settings:

```
:set list
:set listchars=nbsp:¬
```

That will render non-breaking space characters as `¬`, opening your original file reveals that an nbsp character was the problem.